### PR TITLE
When minOccurs or maxOccurs is larger than 1 an invalid WSDL is generated

### DIFF
--- a/src/WSDL.php
+++ b/src/WSDL.php
@@ -420,10 +420,16 @@ class WSDL
                 if ($annotationsCollection->hasAnnotationTag('minOccurs')) {
                     $minOccurs = intval($annotationsCollection->getAnnotation('minOccurs')[0]->getDescription());
                     $element->setAttribute('minOccurs', $minOccurs > 0 ? $minOccurs : 0);
+                    if ($minOccurs > 1) {
+                        $all = $this->changeAllToSequence($all);
+                    }
                 }
                 if ($annotationsCollection->hasAnnotationTag('maxOccurs')) {
                     $maxOccurs = intval($annotationsCollection->getAnnotation('maxOccurs')[0]->getDescription());
                     $element->setAttribute('maxOccurs', $maxOccurs > 0 ? $maxOccurs : 'unbounded');
+                    if ($maxOccurs !== 1) {
+                        $all = $this->changeAllToSequence($all);
+                    }
                 }
                 $all->appendChild($element);
             }
@@ -548,4 +554,28 @@ class WSDL
 
         return str_replace('\\', '.', $type);
     }
+
+    /**
+     * Changes the xs:all to an xs:sequence node
+     *
+     * @param \DOMElement $all
+     * @return \DOMElement
+     */
+    private function changeAllToSequence($all)
+    {
+        if ($all->nodeName !== 'xsd:all') {
+            return $all;
+        }
+        $sequence = $all->ownerDocument->createElement('xsd:sequence');
+        if ($all->attributes->length) {
+            foreach ($all->attributes as $attribute) {
+                $sequence->setAttribute($attribute->nodeName, $attribute->nodeValue);
+            }
+        }
+        while ($all->firstChild) {
+            $sequence->appendChild($all->firstChild);
+        }
+        return $sequence;
+    }
+
 }

--- a/src/WSDL.php
+++ b/src/WSDL.php
@@ -408,20 +408,21 @@ class WSDL
 
         $all = $this->dom->createElement('xsd:all');
         foreach ($class->getProperties() as $property) {
-            if ($property->isPublic() && $property->getReflectionDocComment()->getAnnotationsCollection()->hasAnnotationTag('var')) {
+            $annotationsCollection = $property->getReflectionDocComment()->getAnnotationsCollection();
+            if ($property->isPublic() && $annotationsCollection->hasAnnotationTag('var')) {
                 $element = $this->dom->createElement('xsd:element');
                 $element->setAttribute('name', $property->getName());
-                $propertyVarAnnotation = $property->getReflectionDocComment()->getAnnotationsCollection()->getAnnotation('var');
+                $propertyVarAnnotation = $annotationsCollection->getAnnotation('var');
                 $element->setAttribute('type', $this->getXSDType(reset($propertyVarAnnotation)->getVarType()));
-                if ($property->getReflectionDocComment()->getAnnotationsCollection()->hasAnnotationTag('nillable')) {
+                if ($annotationsCollection->hasAnnotationTag('nillable')) {
                     $element->setAttribute('nillable', 'true');
                 }
-                if ($property->getReflectionDocComment()->getAnnotationsCollection()->hasAnnotationTag('minOccurs')) {
-                    $minOccurs = intval($property->getReflectionDocComment()->getAnnotationsCollection()->getAnnotation('minOccurs')[0]->getDescription());
+                if ($annotationsCollection->hasAnnotationTag('minOccurs')) {
+                    $minOccurs = intval($annotationsCollection->getAnnotation('minOccurs')[0]->getDescription());
                     $element->setAttribute('minOccurs', $minOccurs > 0 ? $minOccurs : 0);
                 }
-                if ($property->getReflectionDocComment()->getAnnotationsCollection()->hasAnnotationTag('maxOccurs')) {
-                    $maxOccurs = intval($property->getReflectionDocComment()->getAnnotationsCollection()->getAnnotation('maxOccurs')[0]->getDescription());
+                if ($annotationsCollection->hasAnnotationTag('maxOccurs')) {
+                    $maxOccurs = intval($annotationsCollection->getAnnotation('maxOccurs')[0]->getDescription());
                     $element->setAttribute('maxOccurs', $maxOccurs > 0 ? $maxOccurs : 'unbounded');
                 }
                 $all->appendChild($element);

--- a/tests/Expected/DataProvider/TestElementWithMaxOccurances.wsdl
+++ b/tests/Expected/DataProvider/TestElementWithMaxOccurances.wsdl
@@ -4,11 +4,12 @@
     <xsd:schema targetNamespace="localhost">
       <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
       <xsd:complexType name="PHP2WSDL.Test.Stub.MaxOccurance">
-        <xsd:all>
+        <xsd:sequence>
+          <xsd:element name="normalValue" type="xsd:string"/>
           <xsd:element name="string4Times" type="xsd:string" maxOccurs="4"/>
           <xsd:element name="unboundedString" type="xsd:string" maxOccurs="unbounded"/>
           <xsd:element name="stringWithInvalidMaxOccurs" type="xsd:string" maxOccurs="unbounded"/>
-        </xsd:all>
+        </xsd:sequence>
       </xsd:complexType>
     </xsd:schema>
   </types>

--- a/tests/Expected/DataProvider/TestElementWithMinAndMaxOccurancesOfOne.wsdl
+++ b/tests/Expected/DataProvider/TestElementWithMinAndMaxOccurancesOfOne.wsdl
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="localhost" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap-enc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOne" targetNamespace="localhost">
+  <types>
+    <xsd:schema targetNamespace="localhost">
+      <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
+      <xsd:complexType name="PHP2WSDL.Test.Stub.MinMaxOccuranceOfOne">
+        <xsd:all>
+          <xsd:element name="normalValue" type="xsd:string"/>
+          <xsd:element name="requiredString" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        </xsd:all>
+      </xsd:complexType>
+    </xsd:schema>
+  </types>
+  <portType name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOnePort">
+    <operation name="inputObject">
+      <input message="tns:inputObjectIn"/>
+    </operation>
+  </portType>
+  <binding name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOneBinding" type="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOnePort">
+    <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="inputObject">
+      <soap:operation soapAction="localhost#inputObject"/>
+      <input>
+        <soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="localhost"/>
+      </input>
+      <output>
+        <soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="localhost"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOneService">
+    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOnePort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurancesOfOneBinding">
+      <soap:address location="localhost"/>
+    </port>
+  </service>
+  <message name="inputObjectIn">
+    <part name="object" type="tns:PHP2WSDL.Test.Stub.MinMaxOccuranceOfOne"/>
+  </message>
+</definitions>

--- a/tests/Expected/DataProvider/TestElementWithMinOccurances.wsdl
+++ b/tests/Expected/DataProvider/TestElementWithMinOccurances.wsdl
@@ -4,11 +4,12 @@
     <xsd:schema targetNamespace="localhost">
       <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
       <xsd:complexType name="PHP2WSDL.Test.Stub.MinOccurance">
-        <xsd:all>
+        <xsd:sequence>
+          <xsd:element name="normalValue" type="xsd:string"/>
           <xsd:element name="nonRequiredString" type="xsd:string" minOccurs="0"/>
           <xsd:element name="stringWithNegativeMinOccurs" type="xsd:string" minOccurs="0"/>
           <xsd:element name="atLeast3TimesString" type="xsd:string" minOccurs="3"/>
-        </xsd:all>
+        </xsd:sequence>
       </xsd:complexType>
     </xsd:schema>
   </types>

--- a/tests/Fixtures/DataProvider/TestElementWithMinAndMaxOccurancesOfOne.php
+++ b/tests/Fixtures/DataProvider/TestElementWithMinAndMaxOccurancesOfOne.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHP2WSDL\Test\Fixtures\DataProvider;
+
+class TestElementWithMinAndMaxOccurancesOfOne {
+
+    /**
+     * @param \PHP2WSDL\Test\Stub\MinMaxOccuranceOfOne $object Input.
+     */
+    public function inputObject($object) {
+
+    }
+}

--- a/tests/PHP2WSDLTest.php
+++ b/tests/PHP2WSDLTest.php
@@ -43,7 +43,6 @@ class PHP2WSDLTest extends \PHPUnit_Framework_TestCase
                 );
             }
         }
-
         return $data;
     }
 

--- a/tests/Stub/MaxOccurance.php
+++ b/tests/Stub/MaxOccurance.php
@@ -9,6 +9,11 @@ class MaxOccurance {
 
     /**
      * @var string
+     */
+    public $normalValue;
+
+    /**
+     * @var string
      * @maxOccurs 4
      */
     public $string4Times;

--- a/tests/Stub/MinMaxOccuranceOfOne.php
+++ b/tests/Stub/MinMaxOccuranceOfOne.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PHP2WSDL\Test\Stub;
+
+/**
+ * Dummy class containing a minOccurs and a maxOccurs attribute both with a value of 1
+ */
+class MinMaxOccuranceOfOne {
+
+    /**
+     * @var string
+     */
+    public $normalValue;
+
+    /**
+     * @var string
+     * @minOccurs 1
+     * @maxOccurs 1
+     */
+    public $requiredString;
+
+}

--- a/tests/Stub/MinOccurance.php
+++ b/tests/Stub/MinOccurance.php
@@ -9,6 +9,11 @@ class MinOccurance {
 
     /**
      * @var string
+     */
+    public $normalValue;
+
+    /**
+     * @var string
      * @minOccurs 0
      */
     public $nonRequiredString;


### PR DESCRIPTION
When minOccurs or maxOccurs is larger than 1 an invalid WSDL was generated as that is not allowed in xsd:all
Modified the code to change the tag to a xsd:sequence when such situation occurs.
Added/changed some unit tests for this situation.

Also did some minor refactoring so the annotationsCollection is only fetched once per property.