### PR TITLE
Optional dump as file and formatted output argument

### DIFF
--- a/src/PHPClass2WSDL.php
+++ b/src/PHPClass2WSDL.php
@@ -255,12 +255,14 @@ class PHPClass2WSDL
     }
 
     /**
-     * Dump the WSDL as XML string.
+     * Dump the WSDL as XML string or file.
      *
-     * @return string
+     * @param string $filename Filename to dump
+     * @param bool $formatOutput Format output
+     * @return mixed
      */
-    public function dump()
+    public function dump($filename = null, $formatOutput = true)
     {
-        return $this->wsdl->dump();
+        return $this->wsdl->dump($filename, $formatOutput);
     }
 }

--- a/src/PHPClass2WSDL.php
+++ b/src/PHPClass2WSDL.php
@@ -255,14 +255,25 @@ class PHPClass2WSDL
     }
 
     /**
-     * Dump the WSDL as XML string or file.
+     * Dump the WSDL as XML string.
+     *
+     * @param bool $formatOutput Format output
+     * @return mixed
+     */
+    public function dump($formatOutput = true)
+    {
+        return $this->wsdl->dump($formatOutput);
+    }
+
+    /**
+     * Dump the WSDL as file.
      *
      * @param string $filename Filename to dump
      * @param bool $formatOutput Format output
      * @return mixed
      */
-    public function dump($filename = null, $formatOutput = true)
+    public function save($filename, $formatOutput = true)
     {
-        return $this->wsdl->dump($filename, $formatOutput);
+        return $this->wsdl->save($filename, $formatOutput);
     }
 }

--- a/src/WSDL.php
+++ b/src/WSDL.php
@@ -550,25 +550,36 @@ class WSDL
     }
 
     /**
-     * Dump the WSDL as XML string or file.
+     * Dump the WSDL as XML string.
      *
-     * @param string $filename Filename to dump
      * @param bool $formatOutput Format output
      * @return mixed
      */
-    public function dump($filename = null, $formatOutput = true)
+    public function dump($formatOutput = true)
     {
         // Format output
         if ($formatOutput === true) {
             $this->dom->formatOutput = true;
         }
 
-        // Dump into file
-        if ($filename) {
-            return $this->dom->save($filename);
+        return $this->dom->saveXML();
+    }
+
+    /**
+     * Dump the WSDL as file.
+     *
+     * @param string $filename Filename to dump
+     * @param bool $formatOutput Format output
+     * @return mixed
+     */
+    public function save($filename, $formatOutput = true)
+    {
+        // Format output
+        if ($formatOutput === true) {
+            $this->dom->formatOutput = true;
         }
 
-        return $this->dom->saveXML();
+        return $this->dom->save($filename);
     }
 
     /**

--- a/src/WSDL.php
+++ b/src/WSDL.php
@@ -550,13 +550,24 @@ class WSDL
     }
 
     /**
-     * Dump the WSDL as XML string.
+     * Dump the WSDL as XML string or file.
      *
-     * @return string
+     * @param string $filename Filename to dump
+     * @param bool $formatOutput Format output
+     * @return mixed
      */
-    public function dump()
+    public function dump($filename = null, $formatOutput = true)
     {
-        $this->dom->formatOutput = true;
+        // Format output
+        if ($formatOutput === true) {
+            $this->dom->formatOutput = true;
+        }
+
+        // Dump into file
+        if ($filename) {
+            return $this->dom->save($filename);
+        }
+
         return $this->dom->saveXML();
     }
 


### PR DESCRIPTION
Some small changes for the dump() method:

- Added optional filename argument for dump() method to save generated wsdl direct as file.
- Added optional formatOutput argument for dump() method.