### PR TITLE
Reorder generated tags

### DIFF
--- a/src/PHPClass2WSDL.php
+++ b/src/PHPClass2WSDL.php
@@ -124,11 +124,6 @@ class PHPClass2WSDL
         $binding = $this->wsdl->addBinding($qNameClassName . 'Binding', 'tns:' . $qNameClassName . 'Port');
 
         $this->wsdl->addSoapBinding($binding, $this->bindingStyle['style'], $this->bindingStyle['transport']);
-        $this->wsdl->addService(
-            $qNameClassName . 'Service', $qNameClassName . 'Port',
-            'tns:' . $qNameClassName . 'Binding',
-            $this->uri
-        );
 
         $ref = new ReflectionClass($this->class);
         foreach ($ref->getMethods() as $method) {
@@ -136,6 +131,12 @@ class PHPClass2WSDL
                 $this->addMethodToWsdl($method, $port, $binding);
             }
         }
+
+        $this->wsdl->addService(
+            $qNameClassName . 'Service', $qNameClassName . 'Port',
+            'tns:' . $qNameClassName . 'Binding',
+            $this->uri
+        );
     }
 
     /**

--- a/tests/Expected/DataProvider/TestElementWithMaxOccurrences.wsdl
+++ b/tests/Expected/DataProvider/TestElementWithMaxOccurrences.wsdl
@@ -30,12 +30,12 @@
       </output>
     </operation>
   </binding>
+  <message name="inputObjectIn">
+    <part name="object" type="tns:PHP2WSDL.Test.Stub.MaxOccurrences"/>
+  </message>
   <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMaxOccurrencesService">
     <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMaxOccurrencesPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMaxOccurrencesBinding">
       <soap:address location="localhost"/>
     </port>
   </service>
-  <message name="inputObjectIn">
-    <part name="object" type="tns:PHP2WSDL.Test.Stub.MaxOccurrences"/>
-  </message>
 </definitions>

--- a/tests/Expected/DataProvider/TestElementWithMinAndMaxOccurrencesOfOne.wsdl
+++ b/tests/Expected/DataProvider/TestElementWithMinAndMaxOccurrencesOfOne.wsdl
@@ -28,12 +28,12 @@
       </output>
     </operation>
   </binding>
+  <message name="inputObjectIn">
+    <part name="object" type="tns:PHP2WSDL.Test.Stub.MinMaxOccurrencesOfOne"/>
+  </message>
   <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurrencesOfOneService">
     <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurrencesOfOnePort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinAndMaxOccurrencesOfOneBinding">
       <soap:address location="localhost"/>
     </port>
   </service>
-  <message name="inputObjectIn">
-    <part name="object" type="tns:PHP2WSDL.Test.Stub.MinMaxOccurrencesOfOne"/>
-  </message>
 </definitions>

--- a/tests/Expected/DataProvider/TestElementWithMinOccurrences.wsdl
+++ b/tests/Expected/DataProvider/TestElementWithMinOccurrences.wsdl
@@ -30,12 +30,12 @@
       </output>
     </operation>
   </binding>
+  <message name="inputObjectIn">
+    <part name="object" type="tns:PHP2WSDL.Test.Stub.MinOccurrences"/>
+  </message>
   <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinOccurrencesService">
     <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinOccurrencesPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestElementWithMinOccurrencesBinding">
       <soap:address location="localhost"/>
     </port>
   </service>
-  <message name="inputObjectIn">
-    <part name="object" type="tns:PHP2WSDL.Test.Stub.MinOccurrences"/>
-  </message>
 </definitions>

--- a/tests/Expected/DataProvider/TestMethodInputArrayOfObjects.wsdl
+++ b/tests/Expected/DataProvider/TestMethodInputArrayOfObjects.wsdl
@@ -32,12 +32,12 @@
       </output>
     </operation>
   </binding>
+  <message name="inputArrayOfObjectsIn">
+    <part name="objects" type="tns:ArrayOfstdClass"/>
+  </message>
   <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfObjectsService">
     <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfObjectsPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfObjectsBinding">
       <soap:address location="localhost"/>
     </port>
   </service>
-  <message name="inputArrayOfObjectsIn">
-    <part name="objects" type="tns:ArrayOfstdClass"/>
-  </message>
 </definitions>

--- a/tests/Expected/DataProvider/TestMethodInputArrayOfScalars.wsdl
+++ b/tests/Expected/DataProvider/TestMethodInputArrayOfScalars.wsdl
@@ -82,11 +82,6 @@
       </output>
     </operation>
   </binding>
-  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfScalarsService">
-    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfScalarsPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfScalarsBinding">
-      <soap:address location="localhost"/>
-    </port>
-  </service>
   <message name="inputArraySimpleIn">
     <part name="array" type="soap-enc:Array"/>
   </message>
@@ -105,4 +100,9 @@
   <message name="inputArrayFloatIn">
     <part name="floats" type="soap-enc:Array"/>
   </message>
+  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfScalarsService">
+    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfScalarsPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputArrayOfScalarsBinding">
+      <soap:address location="localhost"/>
+    </port>
+  </service>
 </definitions>

--- a/tests/Expected/DataProvider/TestMethodInputBase64Binary.wsdl
+++ b/tests/Expected/DataProvider/TestMethodInputBase64Binary.wsdl
@@ -34,15 +34,15 @@
       </output>
     </operation>
   </binding>
-  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputBase64BinaryService">
-    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputBase64BinaryPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputBase64BinaryBinding">
-      <soap:address location="localhost"/>
-    </port>
-  </service>
   <message name="inputBase64BinaryIn">
     <part name="base64binary" type="xsd:base64Binary"/>
   </message>
   <message name="inputBase64BinaryArrayIn">
     <part name="base64binaries" type="soap-enc:Array"/>
   </message>
+  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputBase64BinaryService">
+    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputBase64BinaryPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputBase64BinaryBinding">
+      <soap:address location="localhost"/>
+    </port>
+  </service>
 </definitions>

--- a/tests/Expected/DataProvider/TestMethodInputWithScalars.wsdl
+++ b/tests/Expected/DataProvider/TestMethodInputWithScalars.wsdl
@@ -97,11 +97,6 @@
       </output>
     </operation>
   </binding>
-  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputWithScalarsService">
-    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputWithScalarsPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputWithScalarsBinding">
-      <soap:address location="localhost"/>
-    </port>
-  </service>
   <message name="inputStringIn">
     <part name="input" type="xsd:string"/>
   </message>
@@ -127,4 +122,9 @@
     <part name="input2" type="xsd:date"/>
     <part name="input3" type="tns:DateTime"/>
   </message>
+  <service name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputWithScalarsService">
+    <port name="PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputWithScalarsPort" binding="tns:PHP2WSDL.Test.Fixtures.DataProvider.TestMethodInputWithScalarsBinding">
+      <soap:address location="localhost"/>
+    </port>
+  </service>
 </definitions>

--- a/tests/Expected/TestGenerateWSDLForURIWithAllComponents.wsdl
+++ b/tests/Expected/TestGenerateWSDLForURIWithAllComponents.wsdl
@@ -24,11 +24,6 @@
       </output>
     </operation>
   </binding>
-  <service name="PHP2WSDL.Test.Fixtures.TestGenerateWSDLForURIWithAllComponentsService">
-    <port name="PHP2WSDL.Test.Fixtures.TestGenerateWSDLForURIWithAllComponentsPort" binding="tns:PHP2WSDL.Test.Fixtures.TestGenerateWSDLForURIWithAllComponentsBinding">
-      <soap:address location="http://usr:pss@example.com:81/path/file.ext?r=a/b/c&amp;a=1&amp;b[]=2&amp;b[]=3"/>
-    </port>
-  </service>
   <message name="addIn">
     <part name="p1" type="xsd:float"/>
     <part name="p2" type="xsd:float"/>
@@ -36,4 +31,9 @@
   <message name="addOut">
     <part name="return" type="xsd:float"/>
   </message>
+  <service name="PHP2WSDL.Test.Fixtures.TestGenerateWSDLForURIWithAllComponentsService">
+    <port name="PHP2WSDL.Test.Fixtures.TestGenerateWSDLForURIWithAllComponentsPort" binding="tns:PHP2WSDL.Test.Fixtures.TestGenerateWSDLForURIWithAllComponentsBinding">
+      <soap:address location="http://usr:pss@example.com:81/path/file.ext?r=a/b/c&amp;a=1&amp;b[]=2&amp;b[]=3"/>
+    </port>
+  </service>
 </definitions>

--- a/tests/Expected/TestSimpleClassWithSoapTagAnnotations.wsdl
+++ b/tests/Expected/TestSimpleClassWithSoapTagAnnotations.wsdl
@@ -24,11 +24,6 @@
       </output>
     </operation>
   </binding>
-  <service name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithSoapTagAnnotationsService">
-    <port name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithSoapTagAnnotationsPort" binding="tns:PHP2WSDL.Test.Fixtures.TestSimpleClassWithSoapTagAnnotationsBinding">
-      <soap:address location="localhost"/>
-    </port>
-  </service>
   <message name="addIn">
     <part name="p1" type="xsd:float"/>
     <part name="p2" type="xsd:float"/>
@@ -36,4 +31,9 @@
   <message name="addOut">
     <part name="return" type="xsd:float"/>
   </message>
+  <service name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithSoapTagAnnotationsService">
+    <port name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithSoapTagAnnotationsPort" binding="tns:PHP2WSDL.Test.Fixtures.TestSimpleClassWithSoapTagAnnotationsBinding">
+      <soap:address location="localhost"/>
+    </port>
+  </service>
 </definitions>

--- a/tests/Expected/TestSimpleClassWithoutSoapTagAnnotations.wsdl
+++ b/tests/Expected/TestSimpleClassWithoutSoapTagAnnotations.wsdl
@@ -51,11 +51,6 @@
       </output>
     </operation>
   </binding>
-  <service name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithoutSoapTagAnnotationsService">
-    <port name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithoutSoapTagAnnotationsPort" binding="tns:PHP2WSDL.Test.Fixtures.TestSimpleClassWithoutSoapTagAnnotationsBinding">
-      <soap:address location="localhost"/>
-    </port>
-  </service>
   <message name="__constructIn">
     <part name="param2" type="xsd:string"/>
   </message>
@@ -73,4 +68,9 @@
   <message name="makeArrayOut">
     <part name="return" type="soap-enc:Array"/>
   </message>
+  <service name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithoutSoapTagAnnotationsService">
+    <port name="PHP2WSDL.Test.Fixtures.TestSimpleClassWithoutSoapTagAnnotationsPort" binding="tns:PHP2WSDL.Test.Fixtures.TestSimpleClassWithoutSoapTagAnnotationsBinding">
+      <soap:address location="localhost"/>
+    </port>
+  </service>
 </definitions>


### PR DESCRIPTION
Previous ordering was working but reported incorrect, by
wsdl-analyzer.com and others (SAP)