### PR TITLE
Add nillable when you define a classic type

### DIFF
--- a/src/PHPClass2WSDL.php
+++ b/src/PHPClass2WSDL.php
@@ -188,6 +188,10 @@ class PHPClass2WSDL
                 }
 
                 $args[$param->getName()] = array('type' => $this->wsdl->getXSDType($type));
+
+                if ($param->isOptional()) {
+                    $args[$param->getName()]['nillable'] = 'true';
+                }
             }
         }
 


### PR DESCRIPTION
This code
```php
    /**
     * @soap
     * @param string $ctcCode Contact
     * @return string
     */
    public function service($ctcCode = null)
```
should generate this xml 
```xml
<part name="ctcCode" type="xsd:int" nillable="true"/>
```

Thank you :) 