### PR TITLE
Fix deprecations for PHP 8.4

### DIFF
--- a/src/PHPClass2WSDL.php
+++ b/src/PHPClass2WSDL.php
@@ -250,7 +250,7 @@ class PHPClass2WSDL
 
         // Add any documentation for the operation.
         $description = $method->getReflectionDocComment()->getFullDescription();
-        if (isset($description) && (strlen($description) > 0)) {
+        if (strlen($description) > 0) {
             $this->wsdl->addDocumentation($portOperation, $description);
         }
 

--- a/src/WSDL.php
+++ b/src/WSDL.php
@@ -110,7 +110,6 @@ class WSDL
      * Set the stylesheet for the WSDL.
      *
      * @param string $xslUri The URI to the stylesheet.
-     * @return WSDL
      */
     private function setStylesheet($xslUri)
     {
@@ -211,12 +210,12 @@ class WSDL
      *
      * @param DOMElement $binding The binding element (from addBinding() method).
      * @param string $name The name of the operation.
-     * @param array $input Attributes for the input element (use, namespace, encodingStyle).
-     * @param array $output Attributes for the output element (use, namespace, encodingStyle).
+     * @param array|null $input Attributes for the input element (use, namespace, encodingStyle).
+     * @param array|null $output Attributes for the output element (use, namespace, encodingStyle).
      * @return DOMElement
      * @link http://www.w3.org/TR/wsdl#_soap:body
      */
-    public function addBindingOperation(DOMElement $binding, $name, array $input = null, array $output = null)
+    public function addBindingOperation(DOMElement $binding, $name, ?array $input = null, ?array $output = null)
     {
         $operation = $this->dom->createElement('operation');
         $operation->setAttribute('name', $name);


### PR DESCRIPTION
Fix deprecation warnings for PHP 8.4.
Remove unnecessary isset() call (identified by PHPStan).